### PR TITLE
fix: link to Chrome extension in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Open Chrome.
 Navigate to Settings... Tools... Extensions.
 Click + on "Developer mode"
 Click "Load unpacked extensions..."
-Navigate to directory you installed Jeter Filter and click Open.
+Navigate to directory you installed Trump Filter and click Open.
 Chuckle to self as you reload this page and significant chunks of it suddenly disappear.
 </pre>
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Installation (for Users)
 --------------------------
 
 Just install the extension from [the Chrome Web
-Store](https://chrome.google.com/webstore/detail/pgolkklipgikkpeknefbinnmhlmmdbfa)!
+Store](https://chrome.google.com/webstore/detail/lhondapiaknegjpellpodegmeonigjic)!
 
 Then surf the web, comforted by the protection you are now afforded.
 


### PR DESCRIPTION
this PR fixes the link to Chrome webstore, which was directed to "Jeter filter" rather than "Trump filter".

fixes #3 