### PR TITLE
Bug Fix - Options never save

### DIFF
--- a/js/filter.js
+++ b/js/filter.js
@@ -7,22 +7,22 @@
 // Variables
 var regex = /Trump/i;
 var search = regex.exec(document.body.innerText);
-var $selector = $(":contains('Trump'), :contains('TRUMP'), :contains('trump')");
+
 
 // Functions
 function filterMild() {
 	console.log("Filtering Trump with Mild filter...");
-	return $selector.filter("h1,h2,h3,h4,h5,p,span,li");
+	return $(":contains('Trump'), :contains('TRUMP'), :contains('trump')").filter("h1,h2,h3,h4,h5,p,span,li");
 }
 
 function filterDefault () {
 	console.log("Filtering Trump with Default filter...");
-	return $selector.filter(":only-child").closest('div');
+	return $(":contains('Trump'), :contains('TRUMP'), :contains('trump')").filter(":only-child").closest('div');
 }
 
 function filterVindictive() {
 	console.log("Filtering Trump with Vindictive filter...");
-	return $selector.filter(":not('body'):not('html')");
+	return $(":contains('Trump'), :contains('TRUMP'), :contains('trump')").filter(":not('body'):not('html')");
 }
 
 function getElements(filter) {

--- a/js/filter.js
+++ b/js/filter.js
@@ -1,28 +1,28 @@
 /*
  * Trump Filter - Content Script
- * 
+ *
  * This is the primary JS file that manages the detection and filtration of Donald Trump from the web page.
  */
 
 // Variables
 var regex = /Trump/i;
 var search = regex.exec(document.body.innerText);
-
+var $selector = $(":contains('Trump'), :contains('TRUMP'), :contains('trump')");
 
 // Functions
 function filterMild() {
 	console.log("Filtering Trump with Mild filter...");
-	return $(":contains('Trump'), :contains('TRUMP'), :contains('trump')").filter("h1,h2,h3,h4,h5,p,span,li");
+	return $selector.filter("h1,h2,h3,h4,h5,p,span,li");
 }
 
 function filterDefault () {
 	console.log("Filtering Trump with Default filter...");
-	return $(":contains('Trump'), :contains('TRUMP'), :contains('trump')").filter(":only-child").closest('div');
+	return $selector.filter(":only-child").closest('div');
 }
 
 function filterVindictive() {
 	console.log("Filtering Trump with Vindictive filter...");
-	return $(":contains('Trump'), :contains('TRUMP'), :contains('trump')").filter(":not('body'):not('html')");
+	return $selector.filter(":not('body'):not('html')");
 }
 
 function getElements(filter) {
@@ -51,7 +51,7 @@ if (search) {
 	   elements = getElements(items.filter);
 	   filterElements(elements);
 	   chrome.runtime.sendMessage({method: "saveStats", trumps: elements.length}, function(response) {
-			  console.log("Logging " + elements.length + " trumps."); 
+			  console.log("Logging " + elements.length + " trumps.");
 		 });
 	 });
   chrome.runtime.sendMessage({}, function(response) {});

--- a/js/options.js
+++ b/js/options.js
@@ -3,9 +3,9 @@ function saveOptions() {
 
   chrome.storage.sync.set({
     filter: selectedFilter
-  }, function(items) {
+  }, function() {
     var status = document.getElementById('saveMessage');
-    status.textContent = 'Filter selected - ' + items.filter; 
+    status.textContent = 'Filter selected - ' + selectedFilter;
     setTimeout(function() {
       status.textContent = '';
     }, 750);
@@ -30,7 +30,7 @@ function restoreOptions() {
   getOptions(function(filter) {
     document.getElementById('selectedFilter').value = filter;
   });
-  document.getElementById('selectedFilter').addEventListener('click', saveOptions);
+  document.getElementById('selectedFilter').addEventListener('change', saveOptions);
 }
 
 document.addEventListener('DOMContentLoaded', restoreOptions);


### PR DESCRIPTION
There are 2 issues with the options.js;

1.) saveOptions function is being called on 'click' event of the options dropdown. This is incorrect, as it would never save the new option selected by the user. Therefore, I updated the event to listen on 'change'.

2.) When a user changes the filter aggression it never actually saves.
You seem to expect chrome.storage.sync.set callback to provide an 'items' object, but it doesn't, and so the console.log provides an error and stops running the script.
I have instead provided the 'selectedFilter' variable as part of the successfully saved message output. The options now save as a user would expect on interaction with the options dropdown.