### PR TITLE
add anonymizeIp to google analytics options

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -5,4 +5,5 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 
 ga('create', 'UA-1608534-17', 'auto');
 ga('set', 'checkProtocolTask', null);
+ga('set', 'anonymizeIp', true);
 ga('send', 'pageview', '/background.html');


### PR DESCRIPTION
In relation to reported issue: https://github.com/RobSpectre/Trump-Filter/issues/6
AnonymizeIp added to options of Google Analytics.

You will still need to update the description on the developer dashboard to mention that your extension uses google analytics.
